### PR TITLE
feat(seo): add SEO testing standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ _TBD_
 - [Unit testing](testing/unit.md)
 - [End to End testing](testing/e2e.md)
 - [Security testing](testing/security.md)
+- [SEO testing](testing/seo.md)
 - [Consumer driven contract testing](testing/consumer_driven_contracts.md)
 
 ### Delivery

--- a/testing/seo.md
+++ b/testing/seo.md
@@ -1,25 +1,49 @@
-# Search Engine Optimzation (SEO) testing
+# Search Engine Optimization (SEO) Testing
 
 ## Why
 
 We want our applications to get a good page ranking, when queried by search engine providers.
+SEO considerations also include concerns such as performance, render speed, bundle size, etc ...
+
+This document will only cover testing practices focused on HTML & the DOM.
 
 ## What
 
-By applying SEO testing assertions during our [end to end](e2e.md) tests, we can ensure that our applications have the best possible page ranking.
+TELUS maintains an "SEO Checklist" for best practices and requirements, the following is a subset that covers @developer & @qa concerns **that can be automated**:
+
+
+- [ ] Is the `<h1/>` tag unique and found only once on the website?
+- [ ] Does the `<title>` include the target phrase, in addition to company domain name using a dash ( `-` ) to separate them?
+- [ ] Is the `<title>` meta tag unique and 65 characters or less?
+- [ ] Is you `<meta name="description">` unique and not an exact copy of a paragraph on the first page?
+- [ ] Is the `<meta description>` tag 155 characters or less?
+- [ ] Do you have appropriate and relevant `<meta name="keywords">`?
+- [ ] Does the URL include the exact target phrase with dashes (`-`) between each word of the target phrase?
+- [ ] Are there excessive parameters, session IDs, navigation tags, etc. that can be trimmed off?
+- [ ] Is there only one version of a URL to access the page?
+- [ ] Have you specified an appropriate canonical URL?
+- [ ] Does it exclude provincial parameters, tracking codes and other extra parameters?
+- [ ] Is not broken and do not fall in an infinite loop (i.e. canonicals pointing to each other)?
+- [ ] Are the images `alt` attribute short and descriptive?
+- [ ] Is the image filename appropriately named and separated by underscores?
+- [ ] Is the page indexable through `robots.txt`?
+- [ ] check your site-speed on Webpagetest and/or YellowLab Tools
+- [ ] Are there broken links on the page?
+- [ ] Are development and staging environments blocked from Googlebots via robots.txt?
+- [ ] Have we set language location for the pages ie hreflang attribute?
+- [ ] If applicable, is schema.org markup implemented on the page?
 
 ## How
 
-Current standards that are tested for:
+In our [isomorphic starter kit][starter-kit], we validate the rules above in the [e2e](e2e.md) testing phase using [`nightwatch`][nightwatch] custom assertion library.
 
-- Only one H1 tag per page
-- Images have alt text
-- Title length less than 65 chars
-- Meta description exists and is less than 155 characters
+These are automated [gating](../delivery/continuous-delivery.md#automated-gating) tests. If the tests fail the delivery pipeline will be halted.
+
+## TODO
+
+- [ ] separate the logic from the starter kit into a standalone `nightwatch-seo` library
 
 ## Who
 
-@delivery @qa
-
-## References
-
+- @seo: SEO Checklist
+- @delivery, @developers, @qa: tooling & implementation

--- a/testing/seo.md
+++ b/testing/seo.md
@@ -1,0 +1,25 @@
+# Search Engine Optimzation (SEO) testing
+
+## Why
+
+We want our applications to get a good page ranking, when queried by search engine providers.
+
+## What
+
+By applying SEO testing assertions during our [end to end](e2e.md) tests, we can ensure that our applications have the best possible page ranking.
+
+## How
+
+Current standards that are tested for:
+
+- Only one H1 tag per page
+- Images have alt text
+- Title length less than 65 chars
+- Meta description exists and is less than 155 characters
+
+## Who
+
+@delivery @qa
+
+## References
+


### PR DESCRIPTION
### Outline

Accidentally committed this straight to master. 

Adding SEO testing standards from tech outcomes offsite.

###### Check List

- [x] commits are squashed 
- [x] commits follow the [Karma format][karma-format]

[karma-format]: karma-runner.github.io/1.0/dev/git-commit-msg.html
