### PR TITLE
chore: add placeholders to pr template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,26 +28,25 @@ Before you open an issue or pull request, or ask a question in chat, keep these 
 >
 > 😢 _"I was driving down the highway the other day and stopped for gas, and then I had this amazing idea for something we should be doing, but before I explain that, let me show you..."_
 
-**Keep all communication public.** Unless you need to share sensitive information (such as a security and privacy issue, or a serious concern to the business). When you keep the conversation public, more people can learn and benefit from your exchange. Discussions can be, in themselves, contributions.
+**Keep all communication public.** Unless you need to share sensitive information (such as a security and privacy issue, or a serious concern to the business), keep the conversation public. By doing so, more people can learn and benefit from your exchange. Discussions can be, in themselves, contributions.
 
 > 😇 _(as a comment) "@-maintainer Hi there! How should we proceed on this PR?"_
 >
 > 😢 _(as an email) "Hey there, sorry to bother you over email, but I was wondering if you've had a chance to review my PR"_
 
-**It's okay to ask questions (but be patient!).** Everybody was new to the team at some point, and even experienced team members need to get up to speed when they look at a new project. By the same token, even longtime team members are not always familiar with every part of the project. Show them the same patience that you'd want them to show to you.
+**It's okay to ask questions (but be patient!).** Everybody was new to the team at some point, and even experienced team members needing to get up to speed when they look at a new project. By the same token, even longtime team members are not always familiar with every part of the project. Show them the same patience that you'd want them to show you.
 
 > 😇 _"Thanks for looking into this error. I followed your suggestions. Here's the output."_
 >
 > 😢 _"Why can't you fix my problem? Isn't this your project?"_
 
-**Respect team decisions.** Your ideas may differ from the team's priorities or vision. They may offer feedback or decide not to pursue your idea. While you should discuss and look for compromise, the business will have to live with your decision longer than you will. If you disagree with the team direction, you can always always ask for clarification with the team leads and Principal Architect.
+**Respect team decisions.** Your ideas may differ from the team's priorities or vision. They may offer feedback or decide not to pursue your idea. While you should discuss and look for compromise, the business will have to live with your decision longer than you will. If you disagree with the team direction, you can always ask for clarification with the team leads and Principal Architect.
 
 > 😇 _"I'm disappointed you can't support my use case, but as you've explained it only affects a minor portion of use-cases, I understand why. Thanks for listening."_
 >
 > 😢 _"Why won't you support my use case? This is unacceptable!"_
 
 **Above all, keep it classy.** Context gets lost across squads, teams, and time zones. In addition, written communication makes it harder to convey a tone or mood. Assume good intentions in these conversations. It's fine to politely push back on an idea, ask for more context, or further clarify your position. Just try to leave the technology and technologists in a better place than when you joined.
-
 
 ## Gathering context
 
@@ -81,6 +80,14 @@ You should usually open a pull request in the following situations:
 
 A pull request doesn't have to represent finished work. It's usually better to open a pull request early on, so others can watch or give feedback on your progress. Just mark it as a "WIP" (Work in Progress) in the subject line. You can always add more commits later.
 
+### As your write commits, be sure to:
+
+* Write your commits in the [Karma format][karma-format] or using [Commitizen](https://www.npmjs.com/package/commitizen)
+* Remove any sensitive content such as:
+  - security & privacy policy violating content
+  - content considered competitive intelligence
+  - keys, tokens or credentials
+
 ## What happens after you submit a contribution
 
 You did it! Congratulations on becoming a contributor. We hope it's the first of many.
@@ -110,3 +117,5 @@ Your contribution may or may not be accepted in the end. Hopefully you didn't pu
 Hooray! You've successfully made a contribution!
 
 Don't forget to say thanks when a team member put effort into helping you. Our entire work is made by people like you: one issue, pull request, comment, or high-five at a time.
+
+[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,13 +80,7 @@ You should usually open a pull request in the following situations:
 
 A pull request doesn't have to represent finished work. It's usually better to open a pull request early on, so others can watch or give feedback on your progress. Just mark it as a "WIP" (Work in Progress) in the subject line. You can always add more commits later.
 
-### As your write commits, be sure to:
-
-* Write your commits in the [Karma format][karma-format] or using [Commitizen](https://www.npmjs.com/package/commitizen)
-* Remove any sensitive content such as:
-  - security & privacy policy violating content
-  - content considered competitive intelligence
-  - keys, tokens or credentials
+As your write commits, be sure to check the [pull request template](./PULL_REQUEST_TEMPLATE.md) for guidance.
 
 ## What happens after you submit a contribution
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,19 @@
-###### Check List
+## Overview
+
+Your rationale.
+
+### Features
+
+- add [something] to [doc]
+- create [new doc]
+
+### Fixes
+
+- adjust grammar in [doc]
+
+---
+
+#### Meta
 
 - [ ] provide a descriptive topic
 - [ ] provide an overview of contribution
@@ -7,8 +22,8 @@
   - content considered competitive intelligence
   - keys, tokens or credentials
 - [ ] format follows [this template][template]
-- [ ] commits are squashed 
+- [ ] "work in progress" commits are squashed 
 - [ ] commits follow the [Karma format][karma-format]
 
-[template]: .template.md
-[karma-format]: karma-runner.github.io/1.0/dev/git-commit-msg.html
+[template]: .PULL_REQUEST_TEMPLATE.md
+[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,9 @@ Your rationale.
   - security & privacy policy violating content
   - content considered competitive intelligence
   - keys, tokens or credentials
-- [ ] format follows [this template][template]
+- [ ] documentation format follows [this template][template]
 - [ ] "work in progress" commits are squashed 
-- [ ] commits follow the [Karma format][karma-format]
+- [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format
 
-[template]: .PULL_REQUEST_TEMPLATE.md
+[template]: ../.template.md
 [karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html


### PR DESCRIPTION
## Overview

I believe it would be ideal for contributors to have technical information up front before making a PR since they would likely not see the below checklist until the PR is open and commits have been made.

### Features

- update PR template file to have placeholder headings like this one!
- add technical commit info to contributing.md

### Fixes

- adjust grammar in contributing.md

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] format follows [this template][template]
- [x] "work in progress" commits are squashed 
- [x] commits follow the [Karma format][karma-format]

[template]: .PULL_REQUEST_TEMPLATE.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html