### PR TITLE
docs(pull-request-template): add links to git docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,8 @@ Your rationale.
   - content considered competitive intelligence
   - keys, tokens or credentials
 - [ ] documentation format follows [this template][template]
-- [ ] "work in progress" commits are squashed 
+- [ ] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
+- [ ] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
 - [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format
 
 [template]: ../.template.md


### PR DESCRIPTION
## Overview

Adding links to git docs to explain how to keep a fork up to date and how to squash commits.

### Features

- add links to git docs to PR template

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] "work in progress" commits are squashed 
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html