### PR TITLE
docs(uri_structure): update link

### DIFF
--- a/development/uri-structure.md
+++ b/development/uri-structure.md
@@ -55,7 +55,7 @@ Any teams deploying to www.telus.com:
 - [inbound.telus-gateway-staging-config][telus-gateway-staging-config]
 - [inbound.telus-gateway-production-config][telus-gateway-production-config]
 
-[f5-www.telus.com]: http://www.teluswebteam.com/wiki/doku.php?id=f5_context "F5 Context Paths to AWS for www.telus.com"
+[f5-www.telus.com]: https://telusdigital.atlassian.net/wiki/spaces/TOS/pages/44236901/F5+Context+Paths+to+AWS "F5 Context Paths to AWS for www.telus.com"
 [rfc-6570]: https://tools.ietf.org/html/rfc6570 "RFC 6570"
 [telus-gateway-staging-config]: https://github.com/telusdigital/inbound.telus-gateway-staging-config "inbound.telus-gateway-staging-config"
 [telus-gateway-production-config]: https://github.com/telusdigital/inbound.telus-gateway-production-config "inbound.telus-gateway-production-config"


### PR DESCRIPTION
## Overview

Folks were having trouble viewing the teluswebteam wiki.  Feedback was received that we should move that information to Confluence.

### Features

- update link for F5 context paths from teluswebteam wiki to Confluence for uri-structure.md

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
