### PR TITLE
doc(standards): add defect standards

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -51,18 +51,17 @@ However, you should invest in these tests, __because__ users’ affection and tr
 ---
 #### *Non automated tests*
 
-- Exploratory testing
-- Usability testing 
+- Exploratory testing (WIP)
+- Usability testing (WIP)
 
 ---
 
 ### Standards, processes and culture
 
-- [Browser support standards](standards/browser.md) (WIP)
-- [OS support standards](standards/os.md)(WIP)
-- [Mobile device data](standards/mobiledevice.md) (WIP)
-- [Screensize data](standards/screensize.md) (WIP)
-- [Defect streamlining via JIRA](standards/defect.md) (WIP)
+- [Defect standards][Defect standards]
+- Browser support standards (WIP)
+- OS support standards (WIP)
+
 
 ---
 
@@ -96,3 +95,5 @@ However, you should invest in these tests, __because__ users’ affection and tr
 [Devicefarm_security]: tools_platforms/devicefarm_security.md
 
 [Saucelabs]: tools_platforms/saucelabs.md
+
+[Defect standards]: standards/defect.md

--- a/testing/standards/defect.md
+++ b/testing/standards/defect.md
@@ -12,13 +12,15 @@ We need a standard process of how to
 - Properly report defects
 - Properly monitor defects
 
-To accomplish the above, we use [JIRA][JIRA] for issue tracking, and need to align on the issue type `TD Defect`, which contains useful fields for diagnosis, it also enables data collection and visualization through domo, so that we can do data analytis on defects across all teams.
+To accomplish the above, we use [JIRA][JIRA] for issue tracking, and align on using the issue type `TD Defect` for all production and staging defect reports.
+
+This specific issue type contains useful fields for diagnosis, it also enables data collection and visualization through domo, so that we can do data analytis on defects across all teams.
 
 ## How
 
 JIRA:
 
-For all projects, make sure the issue type `TD Defect` is visible by following this [google doc][Enable TD Defect]
+Make sure the issue type `TD Defect` is enabled for your project by following this [google doc][Enable TD Defect]
 
 When logging defects, make sure to provide as much information as possible, such as:
 
@@ -33,7 +35,7 @@ When logging defects, make sure to provide as much information as possible, such
 So that application owners can easily identify and investigate the problem.
 
 As mentioned in the `What` section, we want to be able to visualize defect data.
-These are tracked in [the Domo/defect reports][DOMO: defect] view
+These are tracked in [the Domo/defect reports][DOMO: defect] view.
 
 ## FAQ
 

--- a/testing/standards/defect.md
+++ b/testing/standards/defect.md
@@ -1,0 +1,55 @@
+# Defect standards
+
+## Why
+
+- We want to provide sufficient and wholistic information to developers on defects/issues found, in order to properly diagnose, reproduce, and resolve them.
+
+- We want to be able to monitor and measure production and staging defects to see the application health and trend, in order to make informed decisions on specific areas for improvement.
+
+## What
+
+We need a standard process of how to
+- Properly report defects
+- Properly monitor defects
+
+To accomplish the above, we use [JIRA][JIRA] for issue tracking, and need to align on the issue type `TD Defect`, which contains useful fields for diagnosis, it also enables data collection and visualization through domo, so that we can do data analytis on defects across all teams.
+
+## How
+
+JIRA:
+
+For all projects, make sure the issue type `TD Defect` is visible by following this [google doc][Enable TD Defect]
+
+When logging defects, make sure to provide as much information as possible, such as:
+
+- Defect Priority
+- Testing environment
+- Method of discovery
+- Defect nature
+- Breakpoint/Screensize
+- Browser type
+- Operating system 
+
+So that application owners can easily identify and investigate the problem.
+
+As mentioned in the `What` section, we want to be able to visualize defect data.
+These are tracked in [the Domo/defect reports][DOMO: defect] view
+
+## FAQ
+
+Q: “TD Defect” is not showing up when I create issue?
+A: That’s because it’s not configured for your project, refer to the documentation: [enabling your project for TD Defect][Enable TD Defect] for instructions.
+
+
+## Who
+
+@qa
+
+## Reference
+* [How to enable your JIRA project to use TD Defect](https://drive.google.com/open?id=1RnsCCp0q7grCmi2nRqOB0-Cnhd1mMBox7uhUSg1EB2k)
+* [TD Defect initialtive doc](https://docs.google.com/document/d/1kupC2NN8nfqjnRILcpYNbeiDbMOye9ngK0T8hL3wqw8)
+* [TD Defect onboarding tracker](https://drive.google.com/open?id=1Wk4Ap_eaUIdess_sZUlIrBTxwzrwdM8NX0wkvXOiAhg)
+
+[Enable TD Defect]: https://docs.google.com/document/d/1RnsCCp0q7grCmi2nRqOB0-Cnhd1mMBox7uhUSg1EB2k
+[JIRA]: https://telusdigital.atlassian.net
+[DOMO: defect]: https://telus.domo.com/page/2123786002

--- a/testing/standards/defect.md
+++ b/testing/standards/defect.md
@@ -20,7 +20,7 @@ This specific issue type contains useful fields for diagnosis, it also enables d
 
 JIRA:
 
-Make sure the issue type `TD Defect` is enabled for your project by following this [google doc][Enable TD Defect]
+Make sure the issue type `TD Defect` is enabled for your project by following this [google doc][Enable TD Defect].
 
 When logging defects, make sure to provide as much information as possible, such as:
 
@@ -28,7 +28,7 @@ When logging defects, make sure to provide as much information as possible, such
 - Defect nature
 - Browser type
 
-etc...
+etc.
 
 So that application owners can easily identify and investigate the problem.
 
@@ -38,6 +38,7 @@ These are tracked in [the Domo/defect reports][DOMO: defect] view.
 ## FAQ
 
 Q: “TD Defect” is not showing up when I create issue?
+
 A: That’s because it’s not configured for your project, refer to the documentation: [enabling your project for TD Defect][Enable TD Defect] for instructions.
 
 

--- a/testing/standards/defect.md
+++ b/testing/standards/defect.md
@@ -14,7 +14,7 @@ We need a standard process of how to
 
 To accomplish the above, we use [JIRA][JIRA] for issue tracking, and align on using the issue type `TD Defect` for all production and staging defect reports.
 
-This specific issue type contains useful fields for diagnosis, it also enables data collection and visualization through domo, so that we can do data analytis on defects across all teams.
+This specific issue type contains useful fields for diagnosis, it also enables data collection and visualization through domo, so that we can do data analysis on defects across all teams.
 
 ## How
 
@@ -24,13 +24,11 @@ Make sure the issue type `TD Defect` is enabled for your project by following th
 
 When logging defects, make sure to provide as much information as possible, such as:
 
-- Defect Priority
 - Testing environment
-- Method of discovery
 - Defect nature
-- Breakpoint/Screensize
 - Browser type
-- Operating system 
+
+etc...
 
 So that application owners can easily identify and investigate the problem.
 
@@ -49,7 +47,7 @@ A: That’s because it’s not configured for your project, refer to the documen
 
 ## Reference
 * [How to enable your JIRA project to use TD Defect](https://drive.google.com/open?id=1RnsCCp0q7grCmi2nRqOB0-Cnhd1mMBox7uhUSg1EB2k)
-* [TD Defect initialtive doc](https://docs.google.com/document/d/1kupC2NN8nfqjnRILcpYNbeiDbMOye9ngK0T8hL3wqw8)
+* [TD Defect initiative doc](https://docs.google.com/document/d/1kupC2NN8nfqjnRILcpYNbeiDbMOye9ngK0T8hL3wqw8)
 * [TD Defect onboarding tracker](https://drive.google.com/open?id=1Wk4Ap_eaUIdess_sZUlIrBTxwzrwdM8NX0wkvXOiAhg)
 
 [Enable TD Defect]: https://docs.google.com/document/d/1RnsCCp0q7grCmi2nRqOB0-Cnhd1mMBox7uhUSg1EB2k

--- a/testing/standards/defect.md
+++ b/testing/standards/defect.md
@@ -54,4 +54,4 @@ A: That’s because it’s not configured for your project, refer to the documen
 
 [Enable TD Defect]: https://docs.google.com/document/d/1RnsCCp0q7grCmi2nRqOB0-Cnhd1mMBox7uhUSg1EB2k
 [JIRA]: https://telusdigital.atlassian.net
-[DOMO: defect]: https://telus.domo.com/page/2123786002
+[DOMO: defect]: https://telus.domo.com/page/1527406136


### PR DESCRIPTION
## Overview

Put in defect reporting and tracking standards (around JIRA's `TD Defect` and DOMO)

### Features

- create RA/testing/standards/defect documentation

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
