### PR TITLE
doc: add sonarqube info and link in unit test section

### DIFF
--- a/testing/functional/unit.md
+++ b/testing/functional/unit.md
@@ -22,6 +22,12 @@ By writing the test first:
 - Implement the feature that makes the test pass
 - Avoid [fragile tests](https://www.youtube.com/watch?v=URSWYvyc42M) and tight coupling
 
+### Code quality metrics
+
+We use [Sonarqube][Sonarqube] for static code analysis purposes.
+
+For details on what value it adds to reference architecture and how to have it set up for your project, check out [Sonarqube in TELUS Digital][Sonarqube in TELUS Digital]
+
 ## When
 
 - Writing unit tests: ideally, before you write the actual code, as we want to follow the [TDD][TDD] practice
@@ -56,3 +62,5 @@ ie: Given a `Card` that gets wrapped in an HoC, the directory structure should l
 
 [Starter-kit: unit test]: https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/DOCKER.md#unit-testing
 [TDD]: https://en.wikipedia.org/wiki/Test-driven_development
+[Sonarqube]: https://github.com/SonarSource/sonarqube
+[Sonarqube in TELUS Digital]: https://github.com/telusdigital/sonarqube


### PR DESCRIPTION
## Overview

https://github.com/telusdigital/sonarqube/issues/1
So that people who search in RA about Sonarqube will have a reference

### Features

- Add Sonarqube link in unit test section

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
