### PR TITLE
feat(devicefarm): add iPhoneX to the listing

### DIFF
--- a/testing/tools_platforms/devicelist.json
+++ b/testing/tools_platforms/devicelist.json
@@ -9,8 +9,9 @@
     "ipadmini4": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPad_Mini4"},
     "ipadair2": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPad_Air2"},
     "ipadpro": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPad_Pro"},
+    "iphonese": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhoneSE"},
+    "iphone6s": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhone6s"},
     "iphone7": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhone7"},
     "iphone7p": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhone7Plus"},
-    "iphonese": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhoneSE"},
-    "iphone6s": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhone6s"}
+    "iphonex": {"browserName": "safari", "platformName":"ios", "deviceName":"TOR_iPhoneX"}   
 }


### PR DESCRIPTION
## Overview

Added iPhoneX to the Devicefarm, enable the Starter-kit [runner integration](https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/e2e/run-devicefarm.sh) by updating the devicelist in RA

### Features

- add iPhoneX to devicelist hosted in RA

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
