### PR TITLE
docs(inbound-proxy): update documentation to point to new sections

### DIFF
--- a/delivery/inbound-proxies.md
+++ b/delivery/inbound-proxies.md
@@ -22,11 +22,12 @@ To have traffic from http://www.wctest.telus.com/en/bc/foo/bar proxied to your a
 
 1. fork https://github.com/telusdigital/inbound.telus-gateway-staging-config
 1. create nginx rule(s) that matches the traffic you're wanting to serve, and proxies them to where your application is hosted
-1. create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-staging-config/blob/master/tests/spec/b4yb_spec.rb#L3-L6)
-1. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-staging-config/blob/master/README.md#testing))
+1. create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-staging-config#writing-tests)
+1. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-staging-config/blob/master/README.md#set-up-everything-and-run-the-tests))
 1. Commit your changes to a branch that contains the Jira Issue Stub, ie BMK-560
 1. Submit a [pull request](https://github.com/telusdigital/inbound.telus-gateway-staging-config). If your request needs merging at a specific time, please note that in your pull request.
-1. Request for this change to be merged in #g-delivery. If you've added a route, but have no tests, it won't be merged.
+1. Your pull request will notify the delivery team in #g-delivery. If you didn't write any tests, your pull request won't get merged.
+1. Once the pull request is merged, the changes will be deployed automatically.
 
 ### Production
 
@@ -34,11 +35,12 @@ To have traffic from http://www.telus.com/en/bc/foo/bar proxied to your applicat
 
 1. fork https://github.com/telusdigital/inbound.telus-gateway-production-config
 1. create nginx rule(s) that matches the traffic you're wanting to serve, and proxies them to where your application is hosted
-1. create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-production-config/blob/master/tests/spec/b4yb_spec.rb#L36-L39)
-1. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-production-config/blob/master/README.md#testing))
+1. create tests confirming that traffic is matched and proxies correctly [example](https://github.com/telusdigital/inbound.telus-gateway-production-config#writing-tests)
+1. Run the tests locally ([README](https://github.com/telusdigital/inbound.telus-gateway-production-config/blob/master/README.md#set-up-everything-and-run-the-tests))
 1. Commit your changes to a branch that contains the Jira Issue Stub, ie BMK-560
 1. Submit a [pull request](https://github.com/telusdigital/inbound.telus-gateway-production-config). If your request needs merging at a specific time, please note that in your pull request.
-1. Request for this change to be merged in #g-delivery.
+1. Your pull request will notify the delivery team in #g-delivery. If you didn't write any tests, your pull request won't get merged.
+1. Once the pull request is merged, the changes will be deployed automatically.
 
 ## Who
 


### PR DESCRIPTION
## Overview

Updating existing documentation to point developers to new documentation written in the inbound proxy repositories.
