### PR TITLE
docs(a11y): Adding dev guidelines imported from Podio

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -36,3 +36,7 @@
 - [Code formatting](code-formatting.md)
 - [ESLint](eslint.md)
 - [Gitignore](gitignore.md)
+
+### Guidelines
+
+ - [Accessibility](accessibility.md)

--- a/development/accessibility.md
+++ b/development/accessibility.md
@@ -1,0 +1,36 @@
+# Accessibility Guide
+
+Dev accessibility at a glance:
+* Automated testing
+* Keyboard accessibility
+* Focus management
+* Label UI elements
+* Best practices: semantic markup, enhance with ARIA
+
+## Automated testing with aXe
+aXe is an accessibility testing engine. In its simplest form it can be used straight into your browser (as Chrome & Firefox plugins) and integrates with the native dev tools.
+* [Chrome link](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd)
+* [Firefox link](https://addons.mozilla.org/en-us/firefox/addon/axe-devtools/)
+
+## Keyboard accessibility
+* `Keyboard focus`: ensure you can TAB through all interactive elements (links, buttons, form fields, navigation menus, dropdowns, pop-ups etc.); watch out for elements that you can’t TAB to and keyboard traps.
+* `Keyboard focus outline`: ensure you can see where you are at all times when you TAB through interactive elements; watch out for elements that don’t have focus outline and hidden elements.
+<br>`Note`: some browsers have their own focus outline (e.g. Chrome’s blue border) - that’s not sufficient. We need to roll our own focus outlines.
+* `Keyboard functionality`: ensure you can interact with all focusable elements by keyboard (not just mouse / hover).
+
+## Focus management
+
+* Interactive elements (menus, expanding sections, etc.) need to have a keyboard model as well, not just a mouse / hover model. 
+
+* Keyboard focus should never reset to the top of the page or “get lost” on the page during interactions. 
+
+* `General rule`: when triggering an action (expanding sections, opening modal menus, etc.) the focus moves from the triggering element to the action; and reversely when the action is completed (collapsing UI, closing a dialog, etc.) the focus moves to the triggering element
+
+## Label UI elements
+Links & buttons have text (`<a></a>` = no bueno), form fields have labels `<label for="field_id">` or a title attribute (if `<label>` doesn't make sense in your UI), images have alt text, etc.
+
+## Use semantic mark-up
+No `<div>` soup for us please. Use HTML elements for their semantic meaning - headings, lists, paragraphs, etc.
+
+## Enhance with ARIA
+Use ARIA landmarks to complement the main HTML sections: https://c1.staticflickr.com/9/8096/8467120722_3e70a8c513_b.jpg


### PR DESCRIPTION
## Overview

Accessibility guidelines on a development perspective. It's been written as a guidelines in our Podio environment. Moving it there to keep track of our standards.

### Features

- create [new doc]

---

#### Meta

- [ ] provide a descriptive topic
- [ ] provide an overview of contribution
- [ ] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [ ] documentation format follows [this template][template]
- [ ] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [ ] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
