### PR TITLE
docs(starter-kit): release process changes

### DIFF
--- a/development/starter-kits.md
+++ b/development/starter-kits.md
@@ -32,18 +32,15 @@ The starter kit projects are designed to be [named anything](https://github.com/
 
 To make a change to a starter kit:
 
-- Fork the starter kit or create a branch
-- Make your changes to the branch (with commit messages using [Karma format](https://conventionalcommits.org/))
+- Make your changes to a branch
 - Once changes are ready, it is recommended that you merge any changes from master, and run `yarn upgrade` to ensure you are up to date
-- Test your branch on the sandbox environment, all the way to "production" ([following the OpenShift setup instructions](https://github.com/telusdigital/telus-isomorphic-starter-kit/blob/master/openshift/README.md))
+- Use shippy to test your branch on the sandbox environment, all the way to "production"
 - If your pipeline fails in sandbox, make the appropriate fixes
 - Once tested end to end, open a pull request (add a link to your sandbox namespace in the comments)
 - For pull requests that are not intended to be merged immediately, make sure you label them as WIP (work in progress)
-- The pull request can be reviewed and completed by members of the Technical Outcomes team or any GitHub administrators
+- The pull request can be reviewed and completed by members of the Delivery team and/or [Digital Architects](https://github.com/orgs/telusdigital/teams/digital-architecture/members)
 - The pull request should be *SQUASHED*, not merged, so that there's one easy-to-follow commit for developers who are merging changes from the starter kit to their older projects
 - If there are any pipeline failures in master, either revert your change, or fix it immediately! This is of paramount importance, as people will be cloning it in a broken state, if it is not fixed.
-- Use GitHub to tag and release the starter kit with a changelog and a new version: Major changes should be reserved for extreme breaking changes (e.g. switching out a core framework used by the tool). Minor changes can denote updates to existing tooling with significant complexity to update. Patch changes can denote trivial updates or newly added tooling that is easily ported.
-- For each release, post in the `#gong` and `#g-developers` slack channel when you make an update, so that developers know to pull the change if they need it
 
 ## Who
 


### PR DESCRIPTION
## Overview

We have removed tagging from the process. It's too manual and serves little purpose. Updated instructions to use shippy and changed references to team members required to approve.

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
