### PR TITLE
docs(api): Added information about custom error responses

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -5,6 +5,7 @@ This section contains documentation related to APIs within TELUS Digital.
 - [Creating an API](creating-an-api.md)
 - [Authorization Proxy](authorization-proxy.md)
 - [Schema Validation](schema-validation.md)
+- [Problem Details](problem-details.md): how to add extra, machine-readable, details to error responses.
 
 ## APIs Outside of Digital
 

--- a/api/problem-details.md
+++ b/api/problem-details.md
@@ -1,0 +1,25 @@
+# Problem Details
+
+## Why
+
+It is particularly important that errors comply with relevant HTTP standards for operational and development analytics.
+
+However, occasionally it might seem like a good idea to enhance standard HTTP error responses with additional, application-specific, information relating to the error. This should be done in a consistent, standards-compliant way across applications.
+
+The error is specific to your application. The format by which that error is reported should not be.
+
+## What
+
+As an API implementor, use [RFC7807][rfc7807] to structure your decoration of the standard error response. Ideally, do this by using the same module as everyone else (TBD, however [see this example][node-error]).
+
+## How
+
+As an API implementor, use a module like [node-error][node-error] to decorate your (otherwise completely standard) HTTP error responses.
+
+## References
+
+- [RFC7807: Problem Details for HTTP APIs][rfc7807]
+- [node-error: Ahmad's implementation of RFC7807](node-error)
+
+[rfc7807]: https://tools.ietf.org/html/rfc7807
+[node-error]: https://github.com/ahmadnassri/node-error


### PR DESCRIPTION
docs(api): Added information about custom error responses (RFC7807: Problem Details for HTTP APIs) to API documentation.

## Overview

It occasionally comes up that people would like to decorate error responses in application-specific ways. This documentation adds standards-compliant guard rails to that urge.

### Features

- add RFC7807 documentation link to README.md
- create problem-details.md documentation page to discuss RFC7807.

---

#### Meta

- [x] provide a descriptive topic
- [x] provide an overview of contribution
- [x] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [x] documentation format follows [this template][template]
- [x] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [x] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [x] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
