### PR TITLE
correct spelling of Design

### DIFF
--- a/development/react.md
+++ b/development/react.md
@@ -14,7 +14,7 @@ Not only can React code be used on the server and client side, there's also [Rea
 
 ## How
 
-[TELUS Deisgn System](http://tds.telus.com/) is our standard library of React components. Where possible, these should be used, rather than creating your own components, so that we can have a consistent design language across all of our pages.
+[TELUS Design System](http://tds.telus.com/) is our standard library of React components. Where possible, these should be used, rather than creating your own components, so that we can have a consistent design language across all of our pages.
 
 The [TELUS Isomorphic Starter Kit](https://github.com/telusdigital/telus-isomorphic-starter-kit) is a standard boilerplate for building a Node.js isomorphic React application. It uses [webpack](webpack.md), and [babel](babel.md) to transpile the React JSX & ES2015 code into browser-native ES5. Using isomorphism, it pre-renders the React components on a page before sending the content to the browser client. After the browser receives the rendered application, it is able to render all further React components on the client side, using AJAX requests to populate it with data.
 


### PR DESCRIPTION
## Overview

While reading the [development/react.md](development/react.md) file, I discovered a typo in the word Design in the term "TELUS Deisgn System". This PR corrects that error.

### Features

- N/A

### Fixes

- fix typo in [development/react.md](development/react.md)

---

#### Meta

- [ ] provide a descriptive topic
- [ ] provide an overview of contribution
- [ ] no sensitive content included, such as:
  - security & privacy policy violating content
  - content considered competitive intelligence
  - keys, tokens or credentials
- [ ] documentation format follows [this template][template]
- [ ] fork is up to date ([see this guide from github](https://help.github.com/articles/syncing-a-fork/))
- [ ] "work in progress" commits are squashed ([see "Squashing Commits"](https://git-scm.com/book/id/v2/Git-Tools-Rewriting-History))
- [ ] commits follow the [Karma][karma-format] or [Commitizen](https://www.npmjs.com/package/commitizen) format

[template]: ../.template.md
[karma-format]: https://karma-runner.github.io/1.0/dev/git-commit-msg.html
